### PR TITLE
[fix] fix prometheus svc selector which conflict with gui

### DIFF
--- a/charts/traffic-guru/templates/_helpers.tpl
+++ b/charts/traffic-guru/templates/_helpers.tpl
@@ -139,6 +139,16 @@ Selector labels
 app.kubernetes.io/name: {{ include "traffic-guru.name" . }}
 {{- end }}
 
+{{- define "traffic-guru.prometheus.labels"}}
+helm.sh/chart: {{ include "traffic-guru.chart" . }}
+app.kubernetes.io/name: prometheus
+app.kubernetes.io/component: prometheus
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
 {{- define "traffic-guru.repository" -}}
 {{- if contains "ubi" .Chart.Version -}}
 quay.io/{{ .Values.image.repository }}

--- a/charts/traffic-guru/templates/prometheus-deployment.yaml
+++ b/charts/traffic-guru/templates/prometheus-deployment.yaml
@@ -5,20 +5,19 @@ metadata:
   name: traffic-guru-prometheus
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    {{- include "traffic-guru.labels" . | nindent 4 }}
+    {{- include "traffic-guru.prometheus.labels" . | nindent 4 }}
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: traffic-guru-prometheus
+      {{- include "traffic-guru.prometheus.labels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "traffic-guru.labels" . | nindent 8 }}
-        app.kubernetes.io/component: prometheus
-        app: traffic-guru-prometheus
+        {{- include "traffic-guru.prometheus.labels" . | nindent 8 }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
       {{- include "restricted.securityContext" . | nindent 6 }}

--- a/charts/traffic-guru/templates/prometheus-svc.yaml
+++ b/charts/traffic-guru/templates/prometheus-svc.yaml
@@ -15,5 +15,5 @@ spec:
     protocol: TCP
     targetPort: {{.Values.prometheus.port}}
   selector:
-    app: traffic-guru-prometheus
+    {{- include "traffic-guru.prometheus.labels" . |nindent 4}}
 {{- end }}


### PR DESCRIPTION
Since the prometheus deployment uses the same `traffic-guru.labels` as traffic-guru, there may be instances where visiting the traffic-guru service results in a connection refused error due to its selector matching with prometheus.

This pr will create new indenpendent labels for prometheus.